### PR TITLE
Relay documentation update 24 2 1

### DIFF
--- a/app/docs/opcon-relay.md
+++ b/app/docs/opcon-relay.md
@@ -10,7 +10,7 @@ This is accomplished by relaying traffic from/to the Agents internal to a custom
 
 ### Diagram
 
-![](../static/img/relay-diagram.png)
+![](../static/img/Relay Diagram 2024-10-09.png)
 
 
 ### Download
@@ -35,7 +35,7 @@ https://files.smatechnologies.com/files/OpCon%20Releases/Relay.
 
 **Q**: What ports need to be open?
 
-**A**: Typically, none, but if you are blocking outbound traffic to the Internet then `TCP:9012`.  If you choose to install Relay within a DMZ, then you will also need to open inbound traffic for all ports used by Agents (default: 3100-3111).
+**A**: Typically, none, but if you are blocking outbound traffic to the Internet then `TCP:9012` and `TCP:9013`.  If you choose to install Relay within a DMZ, then you will also need to open inbound traffic for all ports used by Agents (default: 3100-3111).
 
 **Q**: How do I update the Relay software?
 

--- a/app/docs/opcon-relay.md
+++ b/app/docs/opcon-relay.md
@@ -10,7 +10,7 @@ This is accomplished by relaying traffic from/to the Agents internal to a custom
 
 ### Diagram
 
-![](../static/img/Relay Diagram 2024-10-09.png)
+![](../static/img/Relay_Diagram_2024-10-09.png)
 
 
 ### Download

--- a/app/static/img/Relay_Diagram_2024-10-09.png
+++ b/app/static/img/Relay_Diagram_2024-10-09.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23fe2ef5c311fb75f2e662230a791177001f031c7580c9ce7954661c67506145
+size 52094

--- a/app/static/img/relay-diagram.png
+++ b/app/static/img/relay-diagram.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f378c44f4726d5bf31f1898f37eef5467bbcb24c1ad47a6d93180267ea30618a
-size 132944


### PR DESCRIPTION
This is to update the Relay documentation to reflect the changes in version 24.2.1. The Relay diagram file has been replaced with the updated one and opcon-relay.md has been edited to point to the new diagram and to include the port 9013 requirement.

There was a typo in the file path to the diagram in the first commit submitted (83d86291f7ab1bb1b8c20f10ac93da2ab49dfe09). The second commit (9bba191cee50224ef83722fbff0d8f13bb0d9612) contains the correct information.