### PR TITLE
Update home releases and restyle integrations menu

### DIFF
--- a/app/docs/index.md
+++ b/app/docs/index.md
@@ -14,7 +14,6 @@ title: 'Home'
 | June 8, 2026 | OpCon 25.0.7 | On-Prem | [Release Notes](https://help.smatechnologies.com/opcon/core/v25.0/release-notes#opcon-2507) |
 | April 29, 2026 | Deploy 25.2.2 | Deploy | [Release Notes](https://help.smatechnologies.com/opcon/deploy/release-notes) |
 | April 29, 2026 | UNIX Agent 26.0.0 | Agent | [Release Notes](https://help.smatechnologies.com/opcon/agents/unix/release-notes) |
-| March 30, 2026 | OpCon 23.0.14 | On-Prem | [Release Notes](https://help.smatechnologies.com/opcon/core/v23.0/release-notes#opcon-23014) |
 
 ## OpCon Cloud Releases
 
@@ -58,16 +57,17 @@ On-Prem releases are supported for 3 years from the date of release. Releases th
 <tbody>
 <tr>
 <td style="text-align: center">26.0 LTS</td>
-<td style="text-align: center">26.0.4</td>
-<td style="text-align: center">2026-04-20</td>
+<td style="text-align: center">26.0.5</td>
+<td style="text-align: center">2026-07-07</td>
 <td style="text-align: center">2029-02-28</td>
-<td style="text-align: center"><a href="https://help.smatechnologies.com/opcon/core/v26.0/release-notes#opcon-2604">Release Notes</a></td>
+<td style="text-align: center"><a href="https://help.smatechnologies.com/opcon/core/v26.0/release-notes#opcon-2605">Release Notes</a></td>
 </tr>
 <tr>
 <td colspan="5" style="padding: 10px">
 <details>
 <summary><strong>This release is a continuation of the below release versions</strong></summary>
 <ul>
+<li><strong>26.0.4</strong> | 2026-04-20 | <a href="https://help.smatechnologies.com/opcon/core/v26.0/release-notes#opcon-2604">Release Notes</a></li>
 <li><strong>26.0.2</strong> | 2026-03-19 | <a href="https://help.smatechnologies.com/opcon/core/v26.0/release-notes#opcon-2602">Release Notes</a></li>
 <li><strong>26.0.1</strong> | 2026-02-17 | <a href="https://help.smatechnologies.com/opcon/core/v26.0/release-notes#opcon-2601">Release Notes</a></li>
 </ul>

--- a/app/docs/integrations.md
+++ b/app/docs/integrations.md
@@ -8,202 +8,56 @@ We support the current version and the previous version (for up to one year afte
 
 ### Agents and Connectors
 
-<div class="grid-container">
+<div class="nav-card integrations-list">
 
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/asyscoamt-acs">ACS ASYSCO AMT</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/ease-acs-docs">ACS EASE</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/informatica-onprem-acs">ACS Informatica (On Prem)</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/acs-fiservccm">ACS Fiserv CCM</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/acs-fiservdna">ACS Fiserv DNA</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/acs-kubernetes">ACS Kubernetes</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/webservices-acs">ACS WEBSERVICES</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/asysco-amt">ASYSCO AMT</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/awsec2">AMAZON EC2</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/azure-storage">AZURE STORAGE</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/azure-vm">AZURE VM</a>
-</div>
-
-<div class="grid-item">
- <a class="button button--link button--block button--primary" href="/opcon/connectors/cegid-cbr">CEGID CBR</a>
-</div>
-
-<div class="grid-item">
- <a class="button button--link button--block button--primary" href="/opcon/connectors/cegid-orli">CEGID ORLI</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/commvault">COMMVAULT</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/corelation">CORELATION</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/easyvista">EASYVISTA</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/episys">EPISYS (RSJ)</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/exigen">EXIGEN</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/fics">FICS</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/fiserv-dna">FISERV DNA</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--link button--block button--primary" href="/opcon/connectors/xp2">FISERV XP2</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/guidewire">GUIDEWIRE</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/ibm-i-2101">IBM I (Version 21.1)</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/ibm-i-1801">IBM I (Version 18.1)</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/jaspersoft">JASPERSOFT</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/java">JAVA</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/jdedwards">JD EDWARDS</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/jboss">JBOSS</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/opconmft">MANAGED FILE TRANSFER (MFT)</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/mcp">MCP</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/os2200">OS2200</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/peoplesoft">PEOPLESOFT</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/opcon-rpa">ROBOTIC PROCESS AUTOMATION (RPA)</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/sap">SAP</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/sap-bw">SAP BW</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/sapbo">SAPBO</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/sap-data-services">SAP DATA SERVICES</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/servicenow">SERVICE NOW</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/smart-email">SMART EMAIL</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/sql">SQL</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/symphonysummit">SYMPHONY SUMMIT</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/tuxedo-art">TUXEDO ART</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/unikix">UNIKIX</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/unix">UNIX</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/vmware">VMWARE</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/connectors/webservices">WEBSERVICES</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/windows">WINDOWS</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="https://help.smatechnologies.com/opcon/connectors/wsus">WSUS</a>
-</div>
-
-<div class="grid-item">
-<a class="button button--link button--block button--primary" href="/opcon/agents/zos">ZOS</a>
-</div>
+- [ACS ASYSCO AMT](/opcon/connectors/asyscoamt-acs)
+- [ACS EASE](/opcon/connectors/ease-acs-docs)
+- [ACS Informatica (On Prem)](/opcon/connectors/informatica-onprem-acs)
+- [ACS Fiserv CCM](/opcon/connectors/acs-fiservccm)
+- [ACS Fiserv DNA](/opcon/connectors/acs-fiservdna)
+- [ACS Kubernetes](/opcon/connectors/acs-kubernetes)
+- [ACS WEBSERVICES](/opcon/connectors/webservices-acs)
+- [ASYSCO AMT](/opcon/connectors/asysco-amt)
+- [AMAZON EC2](/opcon/connectors/awsec2)
+- [AZURE STORAGE](/opcon/connectors/azure-storage)
+- [AZURE VM](/opcon/connectors/azure-vm)
+- [CEGID CBR](/opcon/connectors/cegid-cbr)
+- [CEGID ORLI](/opcon/connectors/cegid-orli)
+- [COMMVAULT](/opcon/connectors/commvault)
+- [CORELATION](/opcon/connectors/corelation)
+- [EASYVISTA](/opcon/connectors/easyvista)
+- [EPISYS (RSJ)](/opcon/connectors/episys)
+- [EXIGEN](/opcon/connectors/exigen)
+- [FICS](/opcon/connectors/fics)
+- [FISERV DNA](/opcon/connectors/fiserv-dna)
+- [FISERV XP2](/opcon/connectors/xp2)
+- [GUIDEWIRE](/opcon/agents/guidewire)
+- [IBM I (Version 21.1)](/opcon/agents/ibm-i-2101)
+- [IBM I (Version 18.1)](/opcon/agents/ibm-i-1801)
+- [JASPERSOFT](/opcon/connectors/jaspersoft)
+- [JAVA](/opcon/agents/java)
+- [JD EDWARDS](/opcon/connectors/jdedwards)
+- [JBOSS](/opcon/connectors/jboss)
+- [MANAGED FILE TRANSFER (MFT)](/opcon/agents/opconmft)
+- [MCP](/opcon/agents/mcp)
+- [OS2200](/opcon/agents/os2200)
+- [PEOPLESOFT](/opcon/connectors/peoplesoft)
+- [ROBOTIC PROCESS AUTOMATION (RPA)](/opcon/agents/opcon-rpa)
+- [SAP](/opcon/agents/sap)
+- [SAP BW](/opcon/agents/sap-bw)
+- [SAPBO](/opcon/connectors/sapbo)
+- [SAP DATA SERVICES](/opcon/connectors/sap-data-services)
+- [SERVICE NOW](/opcon/connectors/servicenow)
+- [SMART EMAIL](/opcon/connectors/smart-email)
+- [SQL](/opcon/agents/sql)
+- [SYMPHONY SUMMIT](/opcon/connectors/symphonysummit)
+- [TUXEDO ART](/opcon/agents/tuxedo-art)
+- [UNIKIX](/opcon/connectors/unikix)
+- [UNIX](/opcon/agents/unix)
+- [VMWARE](/opcon/connectors/vmware)
+- [WEBSERVICES](/opcon/connectors/webservices)
+- [WINDOWS](/opcon/agents/windows)
+- [WSUS](https://help.smatechnologies.com/opcon/connectors/wsus)
+- [ZOS](/opcon/agents/zos)
 
 </div>

--- a/app/src/css/custom.css
+++ b/app/src/css/custom.css
@@ -308,6 +308,35 @@
   }
 }
 
+/* ── Integrations page card list ──────────────────────────────────────────── */
+.integrations-list ul {
+  column-count: 3;
+  column-gap: 2.5rem;
+  list-style-position: inside;
+  padding-left: 0;
+  margin: 0;
+}
+
+.integrations-list li {
+  break-inside: avoid;
+  margin-bottom: 0.4rem;
+  white-space: nowrap;
+}
+
+/* Drop to fewer columns on narrower screens so the no-wrap labels
+   don't overflow their column. */
+@media (max-width: 768px) {
+  .integrations-list ul {
+    column-count: 2;
+  }
+}
+
+@media (max-width: 480px) {
+  .integrations-list ul {
+    column-count: 1;
+  }
+}
+
 /* ── Navbar responsive overflow fix ──────────────────────────────────────────
    Docusaurus's hamburger menu activates at ≤996px. With many navbar items the
    bar overflows at intermediate widths. Each item gets its own breakpoint so


### PR DESCRIPTION
## Summary
- Trim **Recent Releases** on the home page to the last three months (drops the March 30, 2026 entry).
- Show **OpCon 26.0.5** as the current 26.0 LTS on-prem release (GA 2026-07-07), moving 26.0.4 into the continuation list.
- Restyle the **Agents and Connectors** menu on the integrations page: replace the button grid with a card-styled, multi-column bulleted link list (3 columns on desktop, no-wrap labels) to match the menu lists used in the other documentation repositories.

## Notes
- A related fix to `acs-fiservccm-docs/sidebars.js` (leading with `index`, adding `operation`, consistent indentation) is **not** in this PR because the `content/` directory is gitignored — it must be pushed to the separate `smatechnologies/acs-fiservccm-docs` repo.
- Verified with a clean `yarn build` (`[SUCCESS] Generated static files`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)