### PR TITLE
Add Resource Monitor release notes page

### DIFF
--- a/app/docs/integrations.md
+++ b/app/docs/integrations.md
@@ -42,6 +42,7 @@ We support the current version and the previous version (for up to one year afte
 - [MCP](/opcon/agents/mcp)
 - [OS2200](/opcon/agents/os2200)
 - [PEOPLESOFT](/opcon/connectors/peoplesoft)
+- [RESOURCE MONITOR](/resource-monitor-release-notes)
 - [ROBOTIC PROCESS AUTOMATION (RPA)](/opcon/agents/opcon-rpa)
 - [SAP](/opcon/agents/sap)
 - [SAP BW](/opcon/agents/sap-bw)

--- a/app/docs/resource-monitor-release-notes.md
+++ b/app/docs/resource-monitor-release-notes.md
@@ -1,0 +1,29 @@
+---
+title: Resource Monitor
+description: Release notes for the most recent releases of SMA Resource Monitor.
+---
+
+# Resource Monitor Release Notes
+
+This page lists changes for each SMA Resource Monitor release, organized by version.
+
+## Release 21.1.0
+
+July 2026
+
+### Fixes
+
+**Log-archive retention now respects the INI file**: The `ArchiveDaysToKeep` setting configured in the INI file is now applied correctly at service startup. In prior releases this value was ignored and the default retention was used instead.
+
+## Release 21.0.0
+
+July 2026
+
+### New Features
+
+**FIPS compliance and .NET Framework 4.8.1**: Resource Monitor has been updated to be FIPS-compliant and now runs on .NET Framework 4.8.1. Both the service and the UI have been rebuilt against the latest FIPS-compliant SMA libraries, and the installer automatically deploys the .NET Framework 4.8.1 runtime as a prerequisite where it is not already present.
+
+### Other Improvements
+
+- Service startup and logging-initialization errors are now written to the Windows Event Log, making installation and configuration issues easier to diagnose.
+- Improved service responsiveness and a cleaner, faster service shutdown.


### PR DESCRIPTION
## Summary
- Add a new **Resource Monitor** page at `/resource-monitor-release-notes` with release notes for the two July 2026 releases (21.1.0 and 21.0.0), formatted to match the release-notes style used in the other documentation repositories.
- Add a **RESOURCE MONITOR** entry to the Agents and Connectors list on the integrations page, linking to the new page.

## Notes
- Verified with a clean `yarn build` (`[SUCCESS]`); the new page and link produce no broken-link warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)