### PR TITLE
Hide external-link icon on navbar links

### DIFF
--- a/app/src/css/custom.css
+++ b/app/src/css/custom.css
@@ -657,6 +657,11 @@
   font-size: 0.85rem;
 }
 
+/* ---- Hide the external-link icon on navbar (and its dropdown) links ---- */
+.navbar [class*="iconExternalLink"] {
+  display: none;
+}
+
 /* ---- Page title rendered as a gradient hero band ---- */
 .theme-doc-markdown > header {
   background: linear-gradient(135deg, #003d4c 0%, var(--ifm-color-primary) 100%);


### PR DESCRIPTION
## Summary
Hide the Docusaurus external-link indicator (the ↗ icon) on header menu links and their dropdown items.

- CSS-only change scoped to `.navbar`, so external-link icons in page/markdown content are unaffected.
- Uses the `[class*="iconExternalLink"]` attribute selector so it keeps working across Docusaurus's hashed CSS-module class names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)